### PR TITLE
Update DB2Grammar.php to fix unaccessible tablePrefix property

### DIFF
--- a/src/Database/Query/Grammars/DB2Grammar.php
+++ b/src/Database/Query/Grammars/DB2Grammar.php
@@ -113,7 +113,7 @@ class DB2Grammar extends Grammar
         $columns = (!empty($components['columns']) ? $components['columns'] . ', ' : 'select');
 
         if ($columns == 'select *, ' && $query->from) {
-            $columns = 'select ' . $this->tablePrefix . $query->from . '.*, ';
+            $columns = 'select ' . $this->getTablePrefix() . $query->from . '.*, ';
         }
 
         $components['columns'] = $this->compileOver($orderings, $columns);


### PR DESCRIPTION
tablePrefix is no longer an Illuminate\Database\Grammar.php property since Laravel 12.